### PR TITLE
Add conceptual module system prototype

### DIFF
--- a/module_system.py
+++ b/module_system.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+import importlib
+import json
+
+@dataclass
+class ParameterDefinition:
+    datatype: str
+    defaultValue: object | None = None
+    hardLimits: dict | None = None
+    softLimits: dict | None = None
+    options: list | None = None
+    source: list[str] = field(default_factory=list)
+    editableInFrontend: bool = True
+    reference: str | None = None
+
+@dataclass
+class ModuleDefinition:
+    moduleName: str
+    moduleId: str
+    logic: str
+    parameters: dict[str, ParameterDefinition]
+    steps: list[str]
+
+    @classmethod
+    def from_json(cls, path: Path) -> "ModuleDefinition":
+        data = json.loads(path.read_text())
+        params = {
+            name: ParameterDefinition(**cfg)
+            for name, cfg in data.get("parameters", {}).items()
+        }
+        return cls(
+            moduleName=data["moduleName"],
+            moduleId=data["moduleId"],
+            logic=data.get("logic", data["moduleId"].lower()),
+            parameters=params,
+            steps=data.get("steps", []),
+        )
+
+class ModuleRuntime:
+    def __init__(self, definition: ModuleDefinition):
+        self.definition = definition
+        self.values = {name: p.defaultValue for name, p in definition.parameters.items()}
+
+    def run(self) -> dict:
+        logic = importlib.import_module(f"modules.{self.definition.logic}_logic")
+        for step in self.definition.steps:
+            func = getattr(logic, step)
+            self.values = func(self.values)
+        return self.values
+
+
+class ProjectRuntime:
+    """Simple container tying a global module with other modules."""
+
+    def __init__(self, global_def: ModuleDefinition, module_defs: list[ModuleDefinition]):
+        self.global_runtime = ModuleRuntime(global_def)
+        self.modules = [ModuleRuntime(md) for md in module_defs]
+
+    def _apply_globals(self, module: ModuleRuntime, global_values: dict):
+        for name, param in module.definition.parameters.items():
+            if "global" in param.source and param.reference:
+                module.values[name] = global_values.get(param.reference)
+
+    def run(self) -> dict:
+        results = {"global": self.global_runtime.run(), "modules": []}
+        for module in self.modules:
+            self._apply_globals(module, results["global"])
+            results["modules"].append(module.run())
+        return results
+
+if __name__ == "__main__":
+    base = Path(__file__).parent / "modules"
+    global_def = ModuleDefinition.from_json(base / "global_mod.json")
+    fb_def = ModuleDefinition.from_json(base / "foerderband_mod.json")
+    project = ProjectRuntime(global_def, [fb_def, fb_def])
+    print(project.run())

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,0 +1,4 @@
+def foerderband_schritt1(params):
+    power = params.get("MotorLeistung", 0)
+    params["Nennstrom"] = power * 2  # Platzhalter-Berechnung
+    return params

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -1,0 +1,24 @@
+{
+  "moduleName": "Förderband",
+  "moduleId": "FB001",
+  "logic": "foerderband",
+  "parameters": {
+    "MotorLeistung": {
+      "datatype": "Decimal",
+      "defaultValue": 5.5,
+      "hardLimits": { "min": 0, "max": 100 },
+      "softLimits": { "min": 1, "max": 75, "warningMessage": "Außerhalb üblicher Werte!" },
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Netzspannung": {
+      "datatype": "Auswahl",
+      "defaultValue": null,
+      "options": ["400V", "600V"],
+      "source": ["global"],
+      "reference": "EING_NENN_SPANNUNG",
+      "editableInFrontend": false
+    }
+  },
+  "steps": ["foerderband_schritt1"]
+}

--- a/modules/global_logic.py
+++ b/modules/global_logic.py
@@ -1,0 +1,1 @@
+# Placeholder logic for global module; no calculation steps defined

--- a/modules/global_mod.json
+++ b/modules/global_mod.json
@@ -1,0 +1,17 @@
+{
+  "moduleName": "Global",
+  "moduleId": "GLOBAL",
+  "logic": "global",
+  "parameters": {
+    "EING_NENN_SPANNUNG": {
+      "datatype": "Auswahl",
+      "options": ["400V", "600V"],
+      "defaultValue": "400V",
+      "hardLimits": null,
+      "softLimits": null,
+      "source": ["user"],
+      "editableInFrontend": true
+    }
+  },
+  "steps": []
+}


### PR DESCRIPTION
## Summary
- introduce a ProjectRuntime orchestrating a global module alongside other modules and mapping global parameters like mains voltage
- add global module definition and placeholder logic
- extend conveyor module to reference global mains voltage and showcase a sample project with two instances

## Testing
- `python module_system.py`
- `python -m py_compile module_system.py modules/foerderband_logic.py modules/global_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_6894efa8a7f08322b4918423da9ec75d