### PR TITLE
Add conceptual module system prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
+venv/
 

--- a/module_system.py
+++ b/module_system.py
@@ -120,4 +120,4 @@ if __name__ == "__main__":
     ]
 
     project = ProjectRuntime(global_def, modules)
-    print(json.dumps(project.run(), indent=2))
+    print(json.dumps(project.run(), indent=2, ensure_ascii=False))

--- a/module_system.py
+++ b/module_system.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+import importlib
+import json
+
+@dataclass
+class ParameterDefinition:
+    datatype: str
+    defaultValue: object | None = None
+    hardLimits: dict | None = None
+    softLimits: dict | None = None
+    options: list | None = None
+    source: list[str] = field(default_factory=list)
+    editableInFrontend: bool = True
+    reference: str | None = None
+
+@dataclass
+class ModuleDefinition:
+    moduleName: str
+    moduleId: str
+    logic: str
+    parameters: dict[str, ParameterDefinition]
+    steps: list[str]
+
+    @classmethod
+    def from_json(cls, path: Path) -> "ModuleDefinition":
+        data = json.loads(path.read_text())
+        params = {
+            name: ParameterDefinition(**cfg)
+            for name, cfg in data.get("parameters", {}).items()
+        }
+        return cls(
+            moduleName=data["moduleName"],
+            moduleId=data["moduleId"],
+            logic=data.get("logic", data["moduleId"].lower()),
+            parameters=params,
+            steps=data.get("steps", []),
+        )
+
+class ModuleRuntime:
+    def __init__(self, definition: ModuleDefinition):
+        self.definition = definition
+        self.values = {name: p.defaultValue for name, p in definition.parameters.items()}
+
+    def run(self) -> dict:
+        logic = importlib.import_module(f"modules.{self.definition.logic}_logic")
+        for step in self.definition.steps:
+            func = getattr(logic, step)
+            self.values = func(self.values)
+        return self.values
+
+
+class ProjectRuntime:
+    """Simple container tying a global module with other modules."""
+
+    def __init__(self, global_def: ModuleDefinition, module_defs: list[ModuleDefinition]):
+        self.global_runtime = ModuleRuntime(global_def)
+        self.modules = [ModuleRuntime(md) for md in module_defs]
+
+    def _apply_globals(self, module: ModuleRuntime, global_values: dict):
+        for name, param in module.definition.parameters.items():
+            if "global" in param.source and param.reference:
+                module.values[name] = global_values.get(param.reference)
+
+    def run(self) -> dict:
+        results = {"global": self.global_runtime.run(), "modules": []}
+        for module in self.modules:
+            self._apply_globals(module, results["global"])
+            results["modules"].append(module.run())
+        return results
+
+if __name__ == "__main__":
+    base = Path(__file__).parent / "modules"
+    global_def = ModuleDefinition.from_json(base / "global_mod.json")
+    fb_def = ModuleDefinition.from_json(base / "foerderband_mod.json")
+    project = ProjectRuntime(global_def, [fb_def, fb_def])
+    print(project.run())

--- a/modules/calc_utils.py
+++ b/modules/calc_utils.py
@@ -1,0 +1,16 @@
+import math
+
+COPPER_RESISTIVITY = 0.018  # ohm mm²/m
+POWER_FACTOR = 0.9
+
+
+def dimension_line(power_kw, length_m, voltage_v, max_drop_percent):
+    """Return (current, cross_section, drop_percent)."""
+    current = power_kw * 1000 / (math.sqrt(3) * voltage_v * POWER_FACTOR)
+    for cs in [1.5, 2.5, 4, 6, 10, 16, 25, 35, 50]:
+        resistance = 2 * length_m * COPPER_RESISTIVITY / cs
+        delta_u = math.sqrt(3) * current * resistance
+        drop_pct = delta_u / voltage_v * 100
+        if drop_pct <= max_drop_percent:
+            return current, cs, drop_pct
+    return current, cs, drop_pct

--- a/modules/calc_utils.py
+++ b/modules/calc_utils.py
@@ -4,13 +4,18 @@ COPPER_RESISTIVITY = 0.018  # ohm mm²/m
 POWER_FACTOR = 0.9
 
 
-def dimension_line(power_kw, length_m, voltage_v, max_drop_percent):
-    """Return (current, cross_section, drop_percent)."""
-    current = power_kw * 1000 / (math.sqrt(3) * voltage_v * POWER_FACTOR)
+def calc_current(power_kw, voltage_v):
+    """Approximate motor current for the given power and voltage."""
+    return power_kw * 1000 / (math.sqrt(3) * voltage_v * POWER_FACTOR)
+
+
+def dimension_line(current_a, length_m, voltage_v, max_drop_percent):
+    """Return (cross_section, drop_percent) for a given current."""
     for cs in [1.5, 2.5, 4, 6, 10, 16, 25, 35, 50]:
         resistance = 2 * length_m * COPPER_RESISTIVITY / cs
-        delta_u = math.sqrt(3) * current * resistance
+        delta_u = math.sqrt(3) * current_a * resistance
         drop_pct = delta_u / voltage_v * 100
         if drop_pct <= max_drop_percent:
-            return current, cs, drop_pct
-    return current, cs, drop_pct
+            return cs, drop_pct
+    return cs, drop_pct
+

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,4 +1,28 @@
-def foerderband_schritt1(params):
-    power = params.get("MotorLeistung", 0)
-    params["Nennstrom"] = power * 2  # Platzhalter-Berechnung
+from .calc_utils import dimension_line
+
+
+def calculate(params):
+    voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
+    length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
+    current, cross_section, drop_pct = dimension_line(
+        params.get("MotorLeistung", 0),
+        length,
+        voltage,
+        params.get("MaxSpannungsabfall", 0),
+    )
+    params.update(
+        {
+            "LeistungskabelLaenge": length,
+            "Nennstrom": round(current, 2),
+            "LeitungQuerschnitt": cross_section,
+            "SpannungsabfallProzent": round(drop_pct, 2),
+            "Schaltschrank": [
+                "Motorschutz",
+                "Schütz",
+            ]
+            if params.get("StartArt") == "DOL"
+            else ["Leitungsschutz", "Frequenzumrichter"],
+            "KabelrohrLaenge": params.get("Laenge", 0),
+        }
+    )
     return params

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,0 +1,4 @@
+def foerderband_schritt1(params):
+    power = params.get("MotorLeistung", 0)
+    params["Nennstrom"] = power * 2  # Platzhalter-Berechnung
+    return params

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,5 +1,5 @@
 import math
-from .calc_utils import dimension_line, POWER_FACTOR
+from .calc_utils import calc_current, dimension_line
 
 
 def calculate(params):
@@ -18,22 +18,21 @@ def calculate(params):
             ]
         else:
             return [
-                {"Typ": "Leitungsschutz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
-                {"Typ": "Frequenzumrichter", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+                {"Typ": "Leitungsschutz", "Nennstrom": round(current, 2)},
+                {"Typ": "Frequenzumrichter", "Nennstrom": round(current, 2)},
             ]
 
     if common or drives == 1:
         power = params.get("MotorLeistung", 0) * drives if common else params.get("MotorLeistung", 0)
-        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
-        current, cross_section, drop_pct = dimension_line(
-            power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+        motor_current = calc_current(power, motor_voltage)
+        cross_section, drop_pct = dimension_line(
+            motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
         )
         params.update(
             {
                 "LeistungskabelLaenge": length,
                 "MotorSpannung": round(motor_voltage, 2),
-                "Motorstrom": round(motor_current, 2),
-                "Nennstrom": round(current, 2),
+                "Motornennstrom": round(motor_current, 2),
                 "LeitungQuerschnitt": cross_section,
                 "SpannungsabfallProzent": round(drop_pct, 2),
                 "Schaltschrank": build_components(power, motor_current),
@@ -44,17 +43,16 @@ def calculate(params):
         drive_results = []
         components = []
         power = params.get("MotorLeistung", 0)
-        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
+        motor_current = calc_current(power, motor_voltage)
         for _ in range(drives):
-            current, cross_section, drop_pct = dimension_line(
-                power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+            cross_section, drop_pct = dimension_line(
+                motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
             )
             drive_results.append(
                 {
                     "LeistungskabelLaenge": length,
                     "MotorSpannung": round(motor_voltage, 2),
-                    "Motorstrom": round(motor_current, 2),
-                    "Nennstrom": round(current, 2),
+                    "Motornennstrom": round(motor_current, 2),
                     "LeitungQuerschnitt": cross_section,
                     "SpannungsabfallProzent": round(drop_pct, 2),
                 }

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,28 +1,71 @@
-from .calc_utils import dimension_line
+import math
+from .calc_utils import dimension_line, POWER_FACTOR
 
 
 def calculate(params):
     voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
+    freq = params.get("Frequenz")
+    motor_voltage = voltage / math.sqrt(3) if params.get("StartArt") == "FU" and freq == 87 else voltage
     length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
-    current, cross_section, drop_pct = dimension_line(
-        params.get("MotorLeistung", 0),
-        length,
-        voltage,
-        params.get("MaxSpannungsabfall", 0),
-    )
-    params.update(
-        {
-            "LeistungskabelLaenge": length,
-            "Nennstrom": round(current, 2),
-            "LeitungQuerschnitt": cross_section,
-            "SpannungsabfallProzent": round(drop_pct, 2),
-            "Schaltschrank": [
-                "Motorschutz",
-                "Schütz",
+    drives = params.get("Antriebe", 1)
+    common = params.get("GemeinsamerStarter", False)
+
+    def build_components(power_kw, current):
+        if params.get("StartArt") == "DOL":
+            return [
+                {"Typ": "Motorschutz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2), "Class": "10A"},
+                {"Typ": "Schütz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
             ]
-            if params.get("StartArt") == "DOL"
-            else ["Leitungsschutz", "Frequenzumrichter"],
-            "KabelrohrLaenge": params.get("Laenge", 0),
-        }
-    )
+        else:
+            return [
+                {"Typ": "Leitungsschutz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+                {"Typ": "Frequenzumrichter", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+            ]
+
+    if common or drives == 1:
+        power = params.get("MotorLeistung", 0) * drives if common else params.get("MotorLeistung", 0)
+        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
+        current, cross_section, drop_pct = dimension_line(
+            power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+        )
+        params.update(
+            {
+                "LeistungskabelLaenge": length,
+                "MotorSpannung": round(motor_voltage, 2),
+                "Motorstrom": round(motor_current, 2),
+                "Nennstrom": round(current, 2),
+                "LeitungQuerschnitt": cross_section,
+                "SpannungsabfallProzent": round(drop_pct, 2),
+                "Schaltschrank": build_components(power, motor_current),
+                "KabelrohrLaenge": params.get("Laenge", 0),
+            }
+        )
+    else:
+        drive_results = []
+        components = []
+        power = params.get("MotorLeistung", 0)
+        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
+        for _ in range(drives):
+            current, cross_section, drop_pct = dimension_line(
+                power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+            )
+            drive_results.append(
+                {
+                    "LeistungskabelLaenge": length,
+                    "MotorSpannung": round(motor_voltage, 2),
+                    "Motorstrom": round(motor_current, 2),
+                    "Nennstrom": round(current, 2),
+                    "LeitungQuerschnitt": cross_section,
+                    "SpannungsabfallProzent": round(drop_pct, 2),
+                }
+            )
+            components.extend(build_components(power, motor_current))
+        params.update(
+            {
+                "Triebe": drive_results,
+                "Schaltschrank": components,
+                "KabelrohrLaenge": params.get("Laenge", 0),
+            }
+        )
     return params
+

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -1,0 +1,24 @@
+{
+  "moduleName": "Förderband",
+  "moduleId": "FB001",
+  "logic": "foerderband",
+  "parameters": {
+    "MotorLeistung": {
+      "datatype": "Decimal",
+      "defaultValue": 5.5,
+      "hardLimits": { "min": 0, "max": 100 },
+      "softLimits": { "min": 1, "max": 75, "warningMessage": "Außerhalb üblicher Werte!" },
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Netzspannung": {
+      "datatype": "Auswahl",
+      "defaultValue": null,
+      "options": ["400V", "600V"],
+      "source": ["global"],
+      "reference": "EING_NENN_SPANNUNG",
+      "editableInFrontend": false
+    }
+  },
+  "steps": ["foerderband_schritt1"]
+}

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -3,6 +3,18 @@
   "moduleId": "FB001",
   "logic": "foerderband",
   "parameters": {
+    "ID": {
+      "datatype": "Text",
+      "defaultValue": "",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Bezeichnung": {
+      "datatype": "Text",
+      "defaultValue": "",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
     "MotorLeistung": {
       "datatype": "Decimal",
       "defaultValue": 5.5,
@@ -11,6 +23,40 @@
       "source": ["user"],
       "editableInFrontend": true
     },
+    "Laenge": {
+      "datatype": "Decimal",
+      "defaultValue": 0,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "StartArt": {
+      "datatype": "Auswahl",
+      "defaultValue": "DOL",
+      "options": ["DOL", "FU"],
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Reparaturschalter": {
+      "datatype": "Auswahl",
+      "defaultValue": "integriert",
+      "options": ["integriert", "extern"],
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Reissleine": {
+      "datatype": "Auswahl",
+      "defaultValue": "beidseitig",
+      "options": ["beidseitig", "links", "rechts", "einseitig", "keine"],
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "AvgCableLength": {
+      "datatype": "Decimal",
+      "defaultValue": null,
+      "source": ["global"],
+      "reference": "AVG_KABEL_LAENGE",
+      "editableInFrontend": false
+    },
     "Netzspannung": {
       "datatype": "Auswahl",
       "defaultValue": null,
@@ -18,7 +64,14 @@
       "source": ["global"],
       "reference": "EING_NENN_SPANNUNG",
       "editableInFrontend": false
+    },
+    "MaxSpannungsabfall": {
+      "datatype": "Decimal",
+      "defaultValue": null,
+      "source": ["global"],
+      "reference": "MAX_SPANNUNGSABFALL",
+      "editableInFrontend": false
     }
   },
-  "steps": ["foerderband_schritt1"]
+  "steps": ["calculate"]
 }

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -23,6 +23,18 @@
       "source": ["user"],
       "editableInFrontend": true
     },
+    "Antriebe": {
+      "datatype": "Integer",
+      "defaultValue": 1,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "GemeinsamerStarter": {
+      "datatype": "Bool",
+      "defaultValue": false,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
     "Laenge": {
       "datatype": "Decimal",
       "defaultValue": 0,

--- a/modules/global_logic.py
+++ b/modules/global_logic.py
@@ -1,0 +1,1 @@
+# Placeholder logic for global module; no calculation steps defined

--- a/modules/global_mod.json
+++ b/modules/global_mod.json
@@ -3,12 +3,48 @@
   "moduleId": "GLOBAL",
   "logic": "global",
   "parameters": {
+    "Kalkulationsname": {
+      "datatype": "Text",
+      "defaultValue": "Anfrage Kunde X",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Kunde": {
+      "datatype": "Text",
+      "defaultValue": "X Recycling",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "Kundennummer": {
+      "datatype": "Text",
+      "defaultValue": "123654",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
     "EING_NENN_SPANNUNG": {
       "datatype": "Auswahl",
       "options": ["400V", "600V"],
       "defaultValue": "400V",
       "hardLimits": null,
       "softLimits": null,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "FREQUENZ": {
+      "datatype": "Decimal",
+      "defaultValue": 50,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "AVG_KABEL_LAENGE": {
+      "datatype": "Decimal",
+      "defaultValue": 25,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "MAX_SPANNUNGSABFALL": {
+      "datatype": "Decimal",
+      "defaultValue": 2.5,
       "source": ["user"],
       "editableInFrontend": true
     }

--- a/modules/global_mod.json
+++ b/modules/global_mod.json
@@ -1,0 +1,17 @@
+{
+  "moduleName": "Global",
+  "moduleId": "GLOBAL",
+  "logic": "global",
+  "parameters": {
+    "EING_NENN_SPANNUNG": {
+      "datatype": "Auswahl",
+      "options": ["400V", "600V"],
+      "defaultValue": "400V",
+      "hardLimits": null,
+      "softLimits": null,
+      "source": ["user"],
+      "editableInFrontend": true
+    }
+  },
+  "steps": []
+}

--- a/modules/splitter_logic.py
+++ b/modules/splitter_logic.py
@@ -1,0 +1,31 @@
+from .calc_utils import dimension_line
+
+
+def calculate(params):
+    voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
+    length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
+    drives = params.get("Antriebe", 1)
+    drive_results = []
+    for _ in range(drives):
+        current, cross_section, drop_pct = dimension_line(
+            params.get("MotorLeistung", 0),
+            length,
+            voltage,
+            params.get("MaxSpannungsabfall", 0),
+        )
+        drive_results.append(
+            {
+                "LeistungskabelLaenge": length,
+                "Nennstrom": round(current, 2),
+                "LeitungQuerschnitt": cross_section,
+                "SpannungsabfallProzent": round(drop_pct, 2),
+            }
+        )
+    params.update(
+        {
+            "Triebe": drive_results,
+            "Schaltschrank": ["Leitungsschutz", "Frequenzumrichter"],
+            "KabelrohrLaenge": params.get("Laenge", 0),
+        }
+    )
+    return params

--- a/modules/splitter_logic.py
+++ b/modules/splitter_logic.py
@@ -1,31 +1,65 @@
-from .calc_utils import dimension_line
+import math
+from .calc_utils import dimension_line, POWER_FACTOR
 
 
 def calculate(params):
     voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
+    freq = params.get("Frequenz")
+    motor_voltage = voltage / math.sqrt(3) if params.get("StartArt") == "FU" and freq == 87 else voltage
     length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
     drives = params.get("Antriebe", 1)
-    drive_results = []
-    for _ in range(drives):
+    common = params.get("GemeinsamerStarter", True)
+
+    def build_components(power_kw, current):
+        return [
+            {"Typ": "Leitungsschutz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+            {"Typ": "Frequenzumrichter", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+        ]
+
+    if common or drives == 1:
+        power = params.get("MotorLeistung", 0) * drives if common else params.get("MotorLeistung", 0)
+        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
         current, cross_section, drop_pct = dimension_line(
-            params.get("MotorLeistung", 0),
-            length,
-            voltage,
-            params.get("MaxSpannungsabfall", 0),
+            power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
         )
-        drive_results.append(
+        params.update(
             {
                 "LeistungskabelLaenge": length,
+                "MotorSpannung": round(motor_voltage, 2),
+                "Motorstrom": round(motor_current, 2),
                 "Nennstrom": round(current, 2),
                 "LeitungQuerschnitt": cross_section,
                 "SpannungsabfallProzent": round(drop_pct, 2),
+                "Schaltschrank": build_components(power, motor_current),
+                "KabelrohrLaenge": params.get("Laenge", 0),
             }
         )
-    params.update(
-        {
-            "Triebe": drive_results,
-            "Schaltschrank": ["Leitungsschutz", "Frequenzumrichter"],
-            "KabelrohrLaenge": params.get("Laenge", 0),
-        }
-    )
+    else:
+        drive_results = []
+        components = []
+        power = params.get("MotorLeistung", 0)
+        motor_current = power * 1000 / (math.sqrt(3) * motor_voltage * POWER_FACTOR)
+        for _ in range(drives):
+            current, cross_section, drop_pct = dimension_line(
+                power, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+            )
+            drive_results.append(
+                {
+                    "LeistungskabelLaenge": length,
+                    "MotorSpannung": round(motor_voltage, 2),
+                    "Motorstrom": round(motor_current, 2),
+                    "Nennstrom": round(current, 2),
+                    "LeitungQuerschnitt": cross_section,
+                    "SpannungsabfallProzent": round(drop_pct, 2),
+                }
+            )
+            components.extend(build_components(power, motor_current))
+        params.update(
+            {
+                "Triebe": drive_results,
+                "Schaltschrank": components,
+                "KabelrohrLaenge": params.get("Laenge", 0),
+            }
+        )
     return params
+

--- a/modules/splitter_mod.json
+++ b/modules/splitter_mod.json
@@ -1,0 +1,20 @@
+{
+  "moduleName": "Splitter 625",
+  "moduleId": "SP001",
+  "logic": "splitter",
+  "parameters": {
+    "ID": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
+    "Bezeichnung": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
+    "MotorLeistung": {"datatype": "Decimal", "defaultValue": 5.5, "source": ["user"], "editableInFrontend": true},
+    "Laenge": {"datatype": "Decimal", "defaultValue": 0, "source": ["user"], "editableInFrontend": true},
+    "StartArt": {"datatype": "Auswahl", "defaultValue": "FU", "options": ["FU"], "source": ["user"], "editableInFrontend": true},
+    "Frequenz": {"datatype": "Decimal", "defaultValue": 50, "source": ["user"], "editableInFrontend": true},
+    "Reparaturschalter": {"datatype": "Auswahl", "defaultValue": "extern", "options": ["integriert", "extern"], "source": ["user"], "editableInFrontend": true},
+    "Reissleine": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
+    "Antriebe": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
+    "AvgCableLength": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "AVG_KABEL_LAENGE", "editableInFrontend": false},
+    "Netzspannung": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "EING_NENN_SPANNUNG", "editableInFrontend": false},
+    "MaxSpannungsabfall": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "MAX_SPANNUNGSABFALL", "editableInFrontend": false}
+  },
+  "steps": ["calculate"]
+}

--- a/modules/splitter_mod.json
+++ b/modules/splitter_mod.json
@@ -12,6 +12,7 @@
     "Reparaturschalter": {"datatype": "Auswahl", "defaultValue": "extern", "options": ["integriert", "extern"], "source": ["user"], "editableInFrontend": true},
     "Reissleine": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
     "Antriebe": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
+    "GemeinsamerStarter": {"datatype": "Bool", "defaultValue": true, "source": ["user"], "editableInFrontend": true},
     "AvgCableLength": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "AVG_KABEL_LAENGE", "editableInFrontend": false},
     "Netzspannung": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "EING_NENN_SPANNUNG", "editableInFrontend": false},
     "MaxSpannungsabfall": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "MAX_SPANNUNGSABFALL", "editableInFrontend": false}


### PR DESCRIPTION
## Summary
- introduce a ProjectRuntime orchestrating a global module alongside other modules and mapping global parameters like mains voltage
- add global module definition and placeholder logic
- extend conveyor module to reference global mains voltage and showcase a sample project with two instances

## Testing
- `python module_system.py`
- `python -m py_compile module_system.py modules/foerderband_logic.py modules/global_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_6894efa8a7f08322b4918423da9ec75d