### PR TITLE
feat: rename parameters and allow cable length override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
       "options": ["OptionA", "OptionB", ...],
       "source": ["global", "user", "reference"],
       "editableInFrontend": true,
-      "reference": "EING_NENN_SPANNUNG"
+        "reference": "input_voltage"
     }
   }
   ```
@@ -103,15 +103,15 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
   ```json
   {
-    "globalParameters": {
-      "EING_NENN_SPANNUNG": {
-        "datatype": "Auswahl",
-        "options": ["400V", "600V"],
-        "defaultValue": "400V",
-        "hardLimits": null,
-        "softLimits": null,
-        "editableInFrontend": false
-      },
+      "globalParameters": {
+        "input_voltage": {
+          "datatype": "Auswahl",
+          "options": ["400V", "600V"],
+          "defaultValue": "400V",
+          "hardLimits": null,
+          "softLimits": null,
+          "editableInFrontend": false
+        },
       "EING_TEMP": {
         "datatype": "Auswahl",
         "options": ["25°C", "30°C", "35°C"],
@@ -144,12 +144,12 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
   * Module untereinander: über `<moduleId>.<parameterName>`, z. B.:
 
     ```json
-    "reference": "FB001.MotorLeistung"
+    "reference": "FB001.motor_rated_power"
     ```
   * Globalmodul: über `global.<parameterName>`, z. B.:
 
     ```json
-    "reference": "global.EING_NENN_SPANNUNG"
+    "reference": "global.input_voltage"
     ```
 * **Lookup-Tabelle:**
 
@@ -170,9 +170,9 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 4\. Ergebnis: Mengengerüst, Materialliste, Zeitaufwand
 
 a = Module können sich den Parametern aus den Globaldaten bedienen oder diese ggf. überschreiben
-Beispiel Reparaturschalter: Global gesetzt auf "intern" kann im Modul per Benutzerauswahl trotzdem auf Nein oder extern gestellt werden.
-Ebenso verhält es sich bei der Kabellänge: Wird vom Benutzer keine definiert, gilt der durchschnittswert aus den Globaldaten.
-Einige Globalparameter sollten aber vor "Modulübersteuerung" geschützt werden, wie z.B. die Nennspannung und Frequenz, hier ist kein Überschreiben möglich.
+Beispiel *repair_switch*: Global gesetzt auf "intern" kann im Modul per Benutzerauswahl trotzdem auf Nein oder extern gestellt werden.
+Ebenso verhält es sich bei der *avg_cable_length*: Wird vom Benutzer keine definiert, gilt der Durchschnittswert aus den Globaldaten.
+Einige Globalparameter sollten jedoch vor "Modulübersteuerung" geschützt werden, wie z.B. die *input_voltage* und *frequency* – hier ist kein Überschreiben möglich.
 
 
 **Eingabeparameter**
@@ -213,7 +213,7 @@ Einige Globalparameter sollten aber vor "Modulübersteuerung" geschützt werden,
 | Steuerungs‑verknüpfung               | Bool                        |
 | Extra Gehäuse für Bedienpult         | Bool                        |
 | Fernwartung                          | Bool                        |
-| Reparaturschalter                    | intern, extern, nein        |
+| repair_switch                        | intern, extern, nein        |
 | SPS                                  | S7‑1200, S7‑1500            |
 | Touch Panel                          | 7″, 12″, 15″                |
 | Funkfernbedienung                    | Bool                        |
@@ -221,7 +221,7 @@ Einige Globalparameter sollten aber vor "Modulübersteuerung" geschützt werden,
 | Einzeladerbeschriftung               | Bool                        |
 | Klimagerät                           | Bool                        |
 | Umgebungstemperatur                  | Auswahl (z. B. 25 °C–35 °C) |
-| Durchschnittliche Kabellänge         | Decimal (Meter)             |
+| avg_cable_length                     | Decimal (Meter)             |
 | Montage kalkuliert                   | Bool                        |
 | Verbissichere Kabel                  | Bool                        |
 

--- a/module_system.py
+++ b/module_system.py
@@ -99,6 +99,7 @@ if __name__ == "__main__":
             "repair_switch": "extern",
             "pull_cord": "links",
             "drive_count": 3,
+            "cable_cross_section": 16,
         }),
         (fb_def, {
             "id": "H103",

--- a/module_system.py
+++ b/module_system.py
@@ -63,7 +63,8 @@ class ProjectRuntime:
     def _apply_globals(self, module: ModuleRuntime, global_values: dict):
         for name, param in module.definition.parameters.items():
             if "global" in param.source and param.reference:
-                module.values[name] = global_values.get(param.reference)
+                if module.values.get(name) is None:
+                    module.values[name] = global_values.get(param.reference)
 
     def run(self) -> dict:
         results = {"global": self.global_runtime.run(), "modules": []}
@@ -80,42 +81,43 @@ if __name__ == "__main__":
 
     modules = [
         (fb_def, {
-            "ID": "H101",
-            "Bezeichnung": "Zuführband",
-            "Laenge": 6,
-            "MotorLeistung": 5.5,
-            "StartArt": "DOL",
-            "Reparaturschalter": "integriert",
-            "Reissleine": "beidseitig",
+            "id": "H101",
+            "label": "Zuführband",
+            "length": 6,
+            "motor_rated_power": 5.5,
+            "start_type": "DOL",
+            "repair_switch": "integriert",
+            "pull_cord": "beidseitig",
         }),
         (sp_def, {
-            "ID": "F102",
-            "Bezeichnung": "Splitter",
-            "Laenge": 5,
-            "MotorLeistung": 5.5,
-            "StartArt": "FU",
-            "Frequenz": 87,
-            "Reparaturschalter": "extern",
-            "Reissleine": "links",
-            "Antriebe": 3,
+            "id": "F102",
+            "label": "Splitter",
+            "length": 5,
+            "motor_rated_power": 5.5,
+            "start_type": "FU",
+            "frequency": 87,
+            "repair_switch": "extern",
+            "pull_cord": "links",
+            "drive_count": 3,
         }),
         (fb_def, {
-            "ID": "H103",
-            "Bezeichnung": "Überkorn",
-            "Laenge": 25,
-            "MotorLeistung": 9.2,
-            "StartArt": "DOL",
-            "Reparaturschalter": "integriert",
-            "Reissleine": "beidseitig",
+            "id": "H103",
+            "label": "Überkorn",
+            "length": 25,
+            "motor_rated_power": 9.2,
+            "start_type": "DOL",
+            "repair_switch": "integriert",
+            "pull_cord": "beidseitig",
+            "avg_cable_length": 40,
         }),
         (fb_def, {
-            "ID": "H104",
-            "Bezeichnung": "Unterkorn",
-            "Laenge": 10,
-            "MotorLeistung": 4.0,
-            "StartArt": "DOL",
-            "Reparaturschalter": "integriert",
-            "Reissleine": "einseitig",
+            "id": "H104",
+            "label": "Unterkorn",
+            "length": 10,
+            "motor_rated_power": 4.0,
+            "start_type": "DOL",
+            "repair_switch": "integriert",
+            "pull_cord": "einseitig",
         }),
     ]
 

--- a/modules/calc_utils.py
+++ b/modules/calc_utils.py
@@ -35,6 +35,8 @@ def calc_current(power_kw, voltage_v, safety_factor=1.01):
     Rückgabe:
         Strom in Ampere (float)
     """
+    if not 0.75 <= power_kw <= 45:
+        raise ValueError("power_kw outside supported range (0.75-45 kW)")
     # Kombinierter Faktor η*cosφ anhand einer logarithmischen Näherung
     eff_cosphi = 0.6557219 + 0.0560407 * math.log(power_kw)
     # Faktor auf realistische Grenzen begrenzen
@@ -44,12 +46,16 @@ def calc_current(power_kw, voltage_v, safety_factor=1.01):
 
 
 def dimension_line(current_a, length_m, voltage_v, max_drop_percent):
-    """Return (cross_section, drop_percent) for a given current."""
+    """Return (cross_section, drop_percent) for a given current.
+
+    Raises ValueError if no suitable cross section is found within the
+    predefined range.
+    """
     for cs in [1.5, 2.5, 4, 6, 10, 16, 25, 35, 50]:
         resistance = 2 * length_m * COPPER_RESISTIVITY / cs
         delta_u = math.sqrt(3) * current_a * resistance
         drop_pct = delta_u / voltage_v * 100
         if drop_pct <= max_drop_percent:
             return cs, drop_pct
-    return cs, drop_pct
+    raise ValueError("requirements exceed available cable sizes")
 

--- a/modules/calc_utils.py
+++ b/modules/calc_utils.py
@@ -59,3 +59,17 @@ def dimension_line(current_a, length_m, voltage_v, max_drop_percent):
             return cs, drop_pct
     raise ValueError("requirements exceed available cable sizes")
 
+
+def calc_voltage_drop(current_a, length_m, voltage_v, cross_section):
+    """Return voltage drop percentage for a given cross section.
+
+    Raises ValueError if the cross section is not one of the supported
+    standard sizes.
+    """
+    valid = [1.5, 2.5, 4, 6, 10, 16, 25, 35, 50]
+    if cross_section not in valid:
+        raise ValueError("cross_section outside supported sizes")
+    resistance = 2 * length_m * COPPER_RESISTIVITY / cross_section
+    delta_u = math.sqrt(3) * current_a * resistance
+    return delta_u / voltage_v * 100
+

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -1,5 +1,5 @@
 import math
-from .calc_utils import calc_current, dimension_line
+from .calc_utils import calc_current, dimension_line, calc_voltage_drop
 
 
 def calculate(params):
@@ -22,12 +22,18 @@ def calculate(params):
                 {"type": "frequency_inverter", "rated_current": round(current, 2)},
             ]
 
+    provided_cs = params.get("cable_cross_section")
+
     if common or drives == 1:
         power = params.get("motor_rated_power", 0) * drives if common else params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
-        cross_section, drop_pct = dimension_line(
-            motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
-        )
+        if provided_cs is not None:
+            drop_pct = calc_voltage_drop(motor_current, length, motor_voltage, provided_cs)
+            cross_section = provided_cs
+        else:
+            cross_section, drop_pct = dimension_line(
+                motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
+            )
         params.update(
             {
                 "power_cable_length": length,
@@ -45,9 +51,13 @@ def calculate(params):
         power = params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
         for _ in range(drives):
-            cross_section, drop_pct = dimension_line(
-                motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
-            )
+            if provided_cs is not None:
+                drop_pct = calc_voltage_drop(motor_current, length, motor_voltage, provided_cs)
+                cross_section = provided_cs
+            else:
+                cross_section, drop_pct = dimension_line(
+                    motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
+                )
             drive_results.append(
                 {
                     "power_cable_length": length,

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -3,66 +3,66 @@ from .calc_utils import calc_current, dimension_line
 
 
 def calculate(params):
-    voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
-    freq = params.get("Frequenz")
-    motor_voltage = voltage / math.sqrt(3) if params.get("StartArt") == "FU" and freq == 87 else voltage
-    length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
-    drives = params.get("Antriebe", 1)
-    common = params.get("GemeinsamerStarter", False)
+    voltage = int(str(params.get("supply_voltage", "0V")).rstrip("V"))
+    freq = params.get("frequency")
+    motor_voltage = voltage / math.sqrt(3) if params.get("start_type") == "FU" and freq == 87 else voltage
+    length = params.get("length", 0) + params.get("avg_cable_length", 0)
+    drives = params.get("drive_count", 1)
+    common = params.get("common_starter", False)
 
     def build_components(power_kw, current):
-        if params.get("StartArt") == "DOL":
+        if params.get("start_type") == "DOL":
             return [
-                {"Typ": "Motorschutz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2), "Class": "10A"},
-                {"Typ": "Schütz", "Leistungsklasse": f"{power_kw} kW", "Nennstrom": round(current, 2)},
+                {"type": "motor_protection", "power_class": f"{power_kw} kW", "rated_current": round(current, 2), "class": "10A"},
+                {"type": "contactor", "power_class": f"{power_kw} kW", "rated_current": round(current, 2)},
             ]
         else:
             return [
-                {"Typ": "Leitungsschutz", "Nennstrom": round(current, 2)},
-                {"Typ": "Frequenzumrichter", "Nennstrom": round(current, 2)},
+                {"type": "circuit_breaker", "rated_current": round(current, 2)},
+                {"type": "frequency_inverter", "rated_current": round(current, 2)},
             ]
 
     if common or drives == 1:
-        power = params.get("MotorLeistung", 0) * drives if common else params.get("MotorLeistung", 0)
+        power = params.get("motor_rated_power", 0) * drives if common else params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
         cross_section, drop_pct = dimension_line(
-            motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+            motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
         )
         params.update(
             {
-                "LeistungskabelLaenge": length,
-                "MotorSpannung": round(motor_voltage, 2),
-                "Motornennstrom": round(motor_current, 2),
-                "LeitungQuerschnitt": cross_section,
-                "SpannungsabfallProzent": round(drop_pct, 2),
-                "Schaltschrank": build_components(power, motor_current),
-                "KabelrohrLaenge": params.get("Laenge", 0),
+                "power_cable_length": length,
+                "motor_voltage": round(motor_voltage, 2),
+                "motor_rated_current": round(motor_current, 2),
+                "cable_cross_section": cross_section,
+                "voltage_drop_percent": round(drop_pct, 2),
+                "control_cabinet": build_components(power, motor_current),
+                "conduit_length": params.get("length", 0),
             }
         )
     else:
         drive_results = []
         components = []
-        power = params.get("MotorLeistung", 0)
+        power = params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
         for _ in range(drives):
             cross_section, drop_pct = dimension_line(
-                motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+                motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
             )
             drive_results.append(
                 {
-                    "LeistungskabelLaenge": length,
-                    "MotorSpannung": round(motor_voltage, 2),
-                    "Motornennstrom": round(motor_current, 2),
-                    "LeitungQuerschnitt": cross_section,
-                    "SpannungsabfallProzent": round(drop_pct, 2),
+                    "power_cable_length": length,
+                    "motor_voltage": round(motor_voltage, 2),
+                    "motor_rated_current": round(motor_current, 2),
+                    "cable_cross_section": cross_section,
+                    "voltage_drop_percent": round(drop_pct, 2),
                 }
             )
             components.extend(build_components(power, motor_current))
         params.update(
             {
-                "Triebe": drive_results,
-                "Schaltschrank": components,
-                "KabelrohrLaenge": params.get("Laenge", 0),
+                "drives": drive_results,
+                "control_cabinet": components,
+                "conduit_length": params.get("length", 0),
             }
         )
     return params

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -62,6 +62,12 @@
       "source": ["user"],
       "editableInFrontend": true
     },
+      "cable_cross_section": {
+        "datatype": "Decimal",
+        "defaultValue": null,
+        "source": ["user"],
+        "editableInFrontend": true
+      },
       "avg_cable_length": {
         "datatype": "Decimal",
         "defaultValue": null,

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -3,19 +3,19 @@
   "moduleId": "FB001",
   "logic": "foerderband",
   "parameters": {
-    "ID": {
+      "id": {
       "datatype": "Text",
       "defaultValue": "",
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Bezeichnung": {
+      "label": {
       "datatype": "Text",
       "defaultValue": "",
       "source": ["user"],
       "editableInFrontend": true
     },
-    "MotorLeistung": {
+      "motor_rated_power": {
       "datatype": "Decimal",
       "defaultValue": 5.5,
       "hardLimits": { "min": 0, "max": 100 },
@@ -23,67 +23,74 @@
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Antriebe": {
+      "drive_count": {
       "datatype": "Integer",
       "defaultValue": 1,
       "source": ["user"],
       "editableInFrontend": true
     },
-    "GemeinsamerStarter": {
+      "common_starter": {
       "datatype": "Bool",
       "defaultValue": false,
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Laenge": {
+      "length": {
       "datatype": "Decimal",
       "defaultValue": 0,
       "source": ["user"],
       "editableInFrontend": true
     },
-    "StartArt": {
+      "start_type": {
       "datatype": "Auswahl",
       "defaultValue": "DOL",
       "options": ["DOL", "FU"],
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Reparaturschalter": {
+      "repair_switch": {
       "datatype": "Auswahl",
       "defaultValue": "integriert",
       "options": ["integriert", "extern"],
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Reissleine": {
+      "pull_cord": {
       "datatype": "Auswahl",
       "defaultValue": "beidseitig",
       "options": ["beidseitig", "links", "rechts", "einseitig", "keine"],
       "source": ["user"],
       "editableInFrontend": true
     },
-    "AvgCableLength": {
-      "datatype": "Decimal",
-      "defaultValue": null,
-      "source": ["global"],
-      "reference": "AVG_KABEL_LAENGE",
-      "editableInFrontend": false
-    },
-    "Netzspannung": {
-      "datatype": "Auswahl",
-      "defaultValue": null,
-      "options": ["400V", "600V"],
-      "source": ["global"],
-      "reference": "EING_NENN_SPANNUNG",
-      "editableInFrontend": false
-    },
-    "MaxSpannungsabfall": {
-      "datatype": "Decimal",
-      "defaultValue": null,
-      "source": ["global"],
-      "reference": "MAX_SPANNUNGSABFALL",
-      "editableInFrontend": false
-    }
+      "avg_cable_length": {
+        "datatype": "Decimal",
+        "defaultValue": null,
+        "source": ["global", "user"],
+        "reference": "avg_cable_length",
+        "editableInFrontend": true
+      },
+      "supply_voltage": {
+        "datatype": "Auswahl",
+        "defaultValue": null,
+        "options": ["400V", "600V"],
+        "source": ["global"],
+        "reference": "input_voltage",
+        "editableInFrontend": false
+      },
+      "frequency": {
+        "datatype": "Decimal",
+        "defaultValue": null,
+        "source": ["global"],
+        "reference": "frequency",
+        "editableInFrontend": false
+      },
+      "max_voltage_drop": {
+        "datatype": "Decimal",
+        "defaultValue": null,
+        "source": ["global"],
+        "reference": "max_voltage_drop",
+        "editableInFrontend": false
+      }
   },
   "steps": ["calculate"]
 }

--- a/modules/global_mod.json
+++ b/modules/global_mod.json
@@ -3,25 +3,25 @@
   "moduleId": "GLOBAL",
   "logic": "global",
   "parameters": {
-    "Kalkulationsname": {
+    "calculation_name": {
       "datatype": "Text",
       "defaultValue": "Anfrage Kunde X",
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Kunde": {
+    "customer": {
       "datatype": "Text",
       "defaultValue": "X Recycling",
       "source": ["user"],
       "editableInFrontend": true
     },
-    "Kundennummer": {
+    "customer_id": {
       "datatype": "Text",
       "defaultValue": "123654",
       "source": ["user"],
       "editableInFrontend": true
     },
-    "EING_NENN_SPANNUNG": {
+    "input_voltage": {
       "datatype": "Auswahl",
       "options": ["400V", "600V"],
       "defaultValue": "400V",
@@ -30,19 +30,19 @@
       "source": ["user"],
       "editableInFrontend": true
     },
-    "FREQUENZ": {
+    "frequency": {
       "datatype": "Decimal",
       "defaultValue": 50,
       "source": ["user"],
       "editableInFrontend": true
     },
-    "AVG_KABEL_LAENGE": {
+    "avg_cable_length": {
       "datatype": "Decimal",
       "defaultValue": 25,
       "source": ["user"],
       "editableInFrontend": true
     },
-    "MAX_SPANNUNGSABFALL": {
+    "max_voltage_drop": {
       "datatype": "Decimal",
       "defaultValue": 2.5,
       "source": ["user"],

--- a/modules/splitter_logic.py
+++ b/modules/splitter_logic.py
@@ -3,60 +3,60 @@ from .calc_utils import calc_current, dimension_line
 
 
 def calculate(params):
-    voltage = int(str(params.get("Netzspannung", "0V")).rstrip("V"))
-    freq = params.get("Frequenz")
-    motor_voltage = voltage / math.sqrt(3) if params.get("StartArt") == "FU" and freq == 87 else voltage
-    length = params.get("Laenge", 0) + params.get("AvgCableLength", 0)
-    drives = params.get("Antriebe", 1)
-    common = params.get("GemeinsamerStarter", True)
+    voltage = int(str(params.get("supply_voltage", "0V")).rstrip("V"))
+    freq = params.get("frequency")
+    motor_voltage = voltage / math.sqrt(3) if params.get("start_type") == "FU" and freq == 87 else voltage
+    length = params.get("length", 0) + params.get("avg_cable_length", 0)
+    drives = params.get("drive_count", 1)
+    common = params.get("common_starter", True)
 
     def build_components(power_kw, current):
         return [
-            {"Typ": "Leitungsschutz", "Nennstrom": round(current, 2)},
-            {"Typ": "Frequenzumrichter", "Nennstrom": round(current, 2)},
+            {"type": "circuit_breaker", "rated_current": round(current, 2)},
+            {"type": "frequency_inverter", "rated_current": round(current, 2)},
         ]
 
     if common or drives == 1:
-        power = params.get("MotorLeistung", 0) * drives if common else params.get("MotorLeistung", 0)
+        power = params.get("motor_rated_power", 0) * drives if common else params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
         cross_section, drop_pct = dimension_line(
-            motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+            motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
         )
         params.update(
             {
-                "LeistungskabelLaenge": length,
-                "MotorSpannung": round(motor_voltage, 2),
-                "Motornennstrom": round(motor_current, 2),
-                "LeitungQuerschnitt": cross_section,
-                "SpannungsabfallProzent": round(drop_pct, 2),
-                "Schaltschrank": build_components(power, motor_current),
-                "KabelrohrLaenge": params.get("Laenge", 0),
+                "power_cable_length": length,
+                "motor_voltage": round(motor_voltage, 2),
+                "motor_rated_current": round(motor_current, 2),
+                "cable_cross_section": cross_section,
+                "voltage_drop_percent": round(drop_pct, 2),
+                "control_cabinet": build_components(power, motor_current),
+                "conduit_length": params.get("length", 0),
             }
         )
     else:
         drive_results = []
         components = []
-        power = params.get("MotorLeistung", 0)
+        power = params.get("motor_rated_power", 0)
         motor_current = calc_current(power, motor_voltage)
         for _ in range(drives):
             cross_section, drop_pct = dimension_line(
-                motor_current, length, motor_voltage, params.get("MaxSpannungsabfall", 0)
+                motor_current, length, motor_voltage, params.get("max_voltage_drop", 0)
             )
             drive_results.append(
                 {
-                    "LeistungskabelLaenge": length,
-                    "MotorSpannung": round(motor_voltage, 2),
-                    "Motornennstrom": round(motor_current, 2),
-                    "LeitungQuerschnitt": cross_section,
-                    "SpannungsabfallProzent": round(drop_pct, 2),
+                    "power_cable_length": length,
+                    "motor_voltage": round(motor_voltage, 2),
+                    "motor_rated_current": round(motor_current, 2),
+                    "cable_cross_section": cross_section,
+                    "voltage_drop_percent": round(drop_pct, 2),
                 }
             )
             components.extend(build_components(power, motor_current))
         params.update(
             {
-                "Triebe": drive_results,
-                "Schaltschrank": components,
-                "KabelrohrLaenge": params.get("Laenge", 0),
+                "drives": drive_results,
+                "control_cabinet": components,
+                "conduit_length": params.get("length", 0),
             }
         )
     return params

--- a/modules/splitter_mod.json
+++ b/modules/splitter_mod.json
@@ -3,19 +3,19 @@
   "moduleId": "SP001",
   "logic": "splitter",
   "parameters": {
-    "ID": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
-    "Bezeichnung": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
-    "MotorLeistung": {"datatype": "Decimal", "defaultValue": 5.5, "source": ["user"], "editableInFrontend": true},
-    "Laenge": {"datatype": "Decimal", "defaultValue": 0, "source": ["user"], "editableInFrontend": true},
-    "StartArt": {"datatype": "Auswahl", "defaultValue": "FU", "options": ["FU"], "source": ["user"], "editableInFrontend": true},
-    "Frequenz": {"datatype": "Decimal", "defaultValue": 50, "source": ["user"], "editableInFrontend": true},
-    "Reparaturschalter": {"datatype": "Auswahl", "defaultValue": "extern", "options": ["integriert", "extern"], "source": ["user"], "editableInFrontend": true},
-    "Reissleine": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
-    "Antriebe": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
-    "GemeinsamerStarter": {"datatype": "Bool", "defaultValue": true, "source": ["user"], "editableInFrontend": true},
-    "AvgCableLength": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "AVG_KABEL_LAENGE", "editableInFrontend": false},
-    "Netzspannung": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "EING_NENN_SPANNUNG", "editableInFrontend": false},
-    "MaxSpannungsabfall": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "MAX_SPANNUNGSABFALL", "editableInFrontend": false}
+      "id": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
+      "label": {"datatype": "Text", "defaultValue": "", "source": ["user"], "editableInFrontend": true},
+      "motor_rated_power": {"datatype": "Decimal", "defaultValue": 5.5, "source": ["user"], "editableInFrontend": true},
+      "length": {"datatype": "Decimal", "defaultValue": 0, "source": ["user"], "editableInFrontend": true},
+      "start_type": {"datatype": "Auswahl", "defaultValue": "FU", "options": ["FU"], "source": ["user"], "editableInFrontend": true},
+      "frequency": {"datatype": "Decimal", "defaultValue": 50, "source": ["user"], "editableInFrontend": true},
+      "repair_switch": {"datatype": "Auswahl", "defaultValue": "extern", "options": ["integriert", "extern"], "source": ["user"], "editableInFrontend": true},
+      "pull_cord": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
+      "drive_count": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
+      "common_starter": {"datatype": "Bool", "defaultValue": true, "source": ["user"], "editableInFrontend": true},
+      "avg_cable_length": {"datatype": "Decimal", "defaultValue": null, "source": ["global", "user"], "reference": "avg_cable_length", "editableInFrontend": true},
+      "supply_voltage": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "input_voltage", "editableInFrontend": false},
+      "max_voltage_drop": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "max_voltage_drop", "editableInFrontend": false}
   },
   "steps": ["calculate"]
 }

--- a/modules/splitter_mod.json
+++ b/modules/splitter_mod.json
@@ -13,6 +13,7 @@
       "pull_cord": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
       "drive_count": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
       "common_starter": {"datatype": "Bool", "defaultValue": true, "source": ["user"], "editableInFrontend": true},
+      "cable_cross_section": {"datatype": "Decimal", "defaultValue": null, "source": ["user"], "editableInFrontend": true},
       "avg_cable_length": {"datatype": "Decimal", "defaultValue": null, "source": ["global", "user"], "reference": "avg_cable_length", "editableInFrontend": true},
       "supply_voltage": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "input_voltage", "editableInFrontend": false},
       "max_voltage_drop": {"datatype": "Decimal", "defaultValue": null, "source": ["global"], "reference": "max_voltage_drop", "editableInFrontend": false}


### PR DESCRIPTION
## Summary
- rename parameters to consistent snake_case naming and adjust module logic
- make average cable length configurable per module and default to global
- abort calc_utils calculations outside supported ranges

## Testing
- `python module_system.py`


------
https://chatgpt.com/codex/tasks/task_e_689867c946588322b99ae0c30f2f93f8