### PR TITLE
Document globals and add Schaltschrank module

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 * Bei mehreren Schaltschränken kann zwischen gemeinsamer Aufstellung (gemeinsamer Hauptschalter) und getrennter Aufstellung (separate Hauptschalter) gewählt werden.
 * Das Modul schlägt Hauptschaltergrößen von 63A, 125A, 250A, 400A oder 630A vor. Ab 400A ist ein separates Einspeisefeld erforderlich, das den Hauptschalter enthält.
 
+Beispiel für einen virtuellen Schaltschrank:
+
+```python
+from pathlib import Path
+from module_system import ModuleDefinition, ModuleRuntime
+
+sc_def = ModuleDefinition.from_json(Path("modules/schaltschrank_mod.json"))
+runtime = ModuleRuntime(
+    sc_def,
+    {
+        "id": "SC1",
+        "label": "Virtueller Schrank",
+        "virtual_cabinet": True,
+        "main_switch_size": "400A",
+    },
+)
+print(runtime.run())
+```
+
 ### Cross-Modul Referenzen
 
 * **Modul-Metadaten:**

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
 2\. \*\*Schalt­schrank­module\*\*
 
-&#x20;  \* Sammeln Elemente aller ausgewählten Prozessmodule
+&#x20;  \* Sammeln Elemente aller ausgewählten Prozessmodule mit Herkunfts-ID
 
-&#x20;  \* Berechnen benötigte Schrankgröße
+&#x20;  \* Schlagen Hauptschaltergrößen vor und berechnen Kapazitätsreserven
 
-&#x20;  \* Überwachen Kapazität (inkl. Reserve)
+&#x20;  \* Überwachen Schrankgröße (Konzept für spätere Füllgradkontrolle)
 
 3\. \*\*Schalt­raum­module\*\*
 
@@ -121,10 +121,10 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
 ### Definition des Schaltschrankmoduls
 
-* Das Schaltschrankmodul (`schaltschrank_mod.json`) sammelt zunächst alle schaltschrankrelevanten Positionen in einem virtuellen Schrank.
+* Das Schaltschrankmodul (`schaltschrank_mod.json`) sammelt zunächst alle schaltschrankrelevanten Positionen in einem virtuellen Schrank und listet sie mit Herkunfts-ID auf.
+* Es schlägt auf Basis der Summe aller Motornennströme (× 0,75) automatisch eine Hauptschalterbaugröße aus 63A, 125A, 250A, 400A oder 630A vor und berechnet die Kapazitätsreserve in %.
+* Ab 400A wird automatisch ein separates Einspeisefeld markiert, das den Hauptschalter enthält.
 * Komponenten können anschließend einem realen Gehäuse zugeordnet werden; ein Konzept zur Überwachung der Füllgrade folgt.
-* Bei mehreren Schaltschränken kann zwischen gemeinsamer Aufstellung (gemeinsamer Hauptschalter) und getrennter Aufstellung (separate Hauptschalter) gewählt werden.
-* Das Modul schlägt Hauptschaltergrößen von 63A, 125A, 250A, 400A oder 630A vor. Ab 400A ist ein separates Einspeisefeld erforderlich, das den Hauptschalter enthält.
 
 Beispiel für einen virtuellen Schaltschrank:
 
@@ -139,7 +139,11 @@ runtime = ModuleRuntime(
         "id": "SC1",
         "label": "Virtueller Schrank",
         "virtual_cabinet": True,
-        "main_switch_size": "400A",
+        "elements": [
+            {"type": "contactor", "rated_current": 10, "origin": "H101"},
+            {"type": "frequency_inverter", "rated_current": 12, "origin": "F102"},
+        ],
+        "motor_currents": [10, 12],
     },
 )
 print(runtime.run())
@@ -273,6 +277,7 @@ Aktuell definierte globale Parameter des Systems:
 
 - Es existieren Prozessmodule (Förderband, Splitter) und ein grundlegendes Schaltschrankmodul; Module für Schalträume sowie eine Füllgradüberwachung der Schaltschränke fehlen noch.
 - Ein Browser-Frontend und Docker-Containerisierung sind aktuell nicht implementiert, obwohl sie als Ziel genannt werden.
+- Die in der Beschreibung erwähnte Wahl der gemeinsamen oder getrennten Aufstellung von Schaltschränken ist derzeit nicht im Code umgesetzt.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
 &#x20;  \* Ermitteln das notwendige Material pro Modul (Schaltschrank- und Baustellenbedarf)
 
+&#x20;  \* Besitzen den Eingabeparameter `operating_load_factor` (Standard 0,8) und liefern daraus den Ausgabeparameter `motor_operating_load`
+
 2\. \*\*Schalt­schrank­module\*\*
 
-&#x20;  \* Sammeln Elemente aller ausgewählten Prozessmodule mit Herkunfts-ID
+&#x20;  \* Sammeln Elemente aller ausgewählten Prozessmodule gruppiert nach Herkunfts-ID
 
 &#x20;  \* Schlagen Hauptschaltergrößen vor und berechnen Kapazitätsreserven
+
+&#x20;  \* Summieren `motor_rated_load` und `motor_operating_load` aller Module
 
 &#x20;  \* Überwachen Schrankgröße (Konzept für spätere Füllgradkontrolle)
 
@@ -121,8 +125,9 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
 ### Definition des Schaltschrankmoduls
 
-* Das Schaltschrankmodul (`schaltschrank_mod.json`) sammelt zunächst alle schaltschrankrelevanten Positionen in einem virtuellen Schrank und listet sie mit Herkunfts-ID auf.
+* Das Schaltschrankmodul (`schaltschrank_mod.json`) sammelt zunächst alle schaltschrankrelevanten Positionen in einem virtuellen Schrank und gruppiert sie nach Herkunfts-ID.
 * Es schlägt auf Basis der Summe aller Motornennströme (× 0,75) automatisch eine Hauptschalterbaugröße aus 63A, 125A, 250A, 400A oder 630A vor und berechnet die Kapazitätsreserve in %.
+* Zusätzlich summiert es `motor_rated_load` und `motor_operating_load` aller Module und stellt diese Gesamtwerte bereit.
 * Ab 400A wird automatisch ein separates Einspeisefeld markiert, das den Hauptschalter enthält.
 * Komponenten können anschließend einem realen Gehäuse zugeordnet werden; ein Konzept zur Überwachung der Füllgrade folgt.
 
@@ -139,11 +144,13 @@ runtime = ModuleRuntime(
         "id": "SC1",
         "label": "Virtueller Schrank",
         "virtual_cabinet": True,
-        "elements": [
-            {"type": "contactor", "rated_current": 10, "origin": "H101"},
-            {"type": "frequency_inverter", "rated_current": 12, "origin": "F102"},
-        ],
+        "elements": {
+            "H101": [{"type": "contactor", "rated_current": 10}],
+            "F102": [{"type": "frequency_inverter", "rated_current": 12}]
+        },
         "motor_currents": [10, 12],
+        "motor_rated_loads": [5.5, 5.5],
+        "motor_operating_loads": [4.4, 4.4],
     },
 )
 print(runtime.run())

--- a/README.md
+++ b/README.md
@@ -103,28 +103,28 @@ Ein browserbasiertes Kalkulationstool entwickeln, das die vorhandene Excelbasis 
 
   ```json
   {
-      "globalParameters": {
-        "input_voltage": {
-          "datatype": "Auswahl",
-          "options": ["400V", "600V"],
-          "defaultValue": "400V",
-          "hardLimits": null,
-          "softLimits": null,
-          "editableInFrontend": false
-        },
-      "EING_TEMP": {
+    "moduleName": "Global",
+    "moduleId": "GLOBAL",
+    "logic": "global",
+    "parameters": {
+      "input_voltage": {
         "datatype": "Auswahl",
-        "options": ["25°C", "30°C", "35°C"],
-        "defaultValue": "25°C",
-        "hardLimits": null,
-        "softLimits": null,
-        "editableInFrontend": false
-      }
+        "options": ["400V", "600V"],
+        "defaultValue": "400V",
+        "editableInFrontend": true
+      },
       // ... weitere globale Parameter
     }
   }
   ```
 * Globalmodul ist Quelle für `source: ["global"]` und wird in anderen Modulen einmalig referenziert.
+
+### Definition des Schaltschrankmoduls
+
+* Das Schaltschrankmodul (`schaltschrank_mod.json`) sammelt zunächst alle schaltschrankrelevanten Positionen in einem virtuellen Schrank.
+* Komponenten können anschließend einem realen Gehäuse zugeordnet werden; ein Konzept zur Überwachung der Füllgrade folgt.
+* Bei mehreren Schaltschränken kann zwischen gemeinsamer Aufstellung (gemeinsamer Hauptschalter) und getrennter Aufstellung (separate Hauptschalter) gewählt werden.
+* Das Modul schlägt Hauptschaltergrößen von 63A, 125A, 250A, 400A oder 630A vor. Ab 400A ist ein separates Einspeisefeld erforderlich, das den Hauptschalter enthält.
 
 ### Cross-Modul Referenzen
 
@@ -202,28 +202,17 @@ Einige Globalparameter sollten jedoch vor "Modulübersteuerung" geschützt werde
 
 \## 2. Globale Parameter
 
-| Parameter                            | Typ/Auswahl                 |
-| ------------------------------------ | --------------------------- |
-| Anlagentyp                           | Sternsieb, Splitter, …      |
-| Ziel-Land                            | Deutschland, Nordamerika, … |
-| Anschlussspannung & Frequenz         | 400 V/50 Hz, 600 V/60 Hz    |
-| # Motoren mit FU & Kabellänge > 50 m | Integer                     |
-| # Bänder mit Seilzugschalter         | Integer                     |
-| # Not-Aus extern                     | Integer                     |
-| Steuerungs‑verknüpfung               | Bool                        |
-| Extra Gehäuse für Bedienpult         | Bool                        |
-| Fernwartung                          | Bool                        |
-| repair_switch                        | intern, extern, nein        |
-| SPS                                  | S7‑1200, S7‑1500            |
-| Touch Panel                          | 7″, 12″, 15″                |
-| Funkfernbedienung                    | Bool                        |
-| # Anlaufwarnung                      | Integer                     |
-| Einzeladerbeschriftung               | Bool                        |
-| Klimagerät                           | Bool                        |
-| Umgebungstemperatur                  | Auswahl (z. B. 25 °C–35 °C) |
-| avg_cable_length                     | Decimal (Meter)             |
-| Montage kalkuliert                   | Bool                        |
-| Verbissichere Kabel                  | Bool                        |
+Aktuell definierte globale Parameter des Systems:
+
+| Parameter          | Typ/Auswahl           | Beschreibung                         |
+| ------------------ | --------------------- | ------------------------------------ |
+| calculation_name   | Text                  | Name der Kalkulation                  |
+| customer           | Text                  | Kunde                                 |
+| customer_id        | Text                  | Kunden-ID                             |
+| input_voltage      | Auswahl (400V, 600V)  | Anschlussspannung                     |
+| frequency          | Decimal (Hz)          | Netzfrequenz                          |
+| avg_cable_length   | Decimal (m)           | Durchschnittliche Kabellänge          |
+| max_voltage_drop   | Decimal (%)           | Maximaler zulässiger Spannungsabfall  |
 
 ---
 
@@ -261,6 +250,30 @@ Einige Globalparameter sollten jedoch vor "Modulübersteuerung" geschützt werde
 
 \* Konfigurierbare Faktortabellen (extern, z. B. JSON/DB)
 
+## Abweichungen zwischen Dokumentation und Code
+
+- Es existieren Prozessmodule (Förderband, Splitter) und ein grundlegendes Schaltschrankmodul; Module für Schalträume sowie eine Füllgradüberwachung der Schaltschränke fehlen noch.
+- Ein Browser-Frontend und Docker-Containerisierung sind aktuell nicht implementiert, obwohl sie als Ziel genannt werden.
+
+## Roadmap
+
+- [x] Moduldefinitionssystem auf Basis von JSON und Python-Logik
+- [x] Globalmodul und Beispiel-Module (Förderband, Splitter) mit Berechnungen
+- [x] Grundlegendes Schaltschrankmodul
+- [ ] Schaltraummodule
+- [ ] Persistenz der Kalkulationen (Datei/DB)
+- [ ] Artikeldaten-Anbindung (SQLite/MSSQL)
+- [ ] Browser-Frontend (z. B. Flask)
+- [ ] Containerisierung (Docker)
+- [ ] Validierung & Plausibilitätschecks
+- [ ] Benutzerrechte & Rollenkonzept
+- [ ] Versionierung der Module
+- [ ] Reporting & Export (PDF/Excel/CSV)
+- [ ] Internationalisierung
+- [ ] API & Integrationen
+- [ ] Performance & Skalierung
+- [ ] UI/UX-Verbesserungen
+
 \---
 
 \## 7. Future Feature Map
@@ -297,18 +310,6 @@ Die folgenden Punkte sind für spätere Entwicklungsphasen geplant und werden ge
 
 &#x20;  \* Caching, Hintergrundspeicherung, Optimierung für große Anlagen
 
-8\. \*\*UI/UX-Verbesserungen (mid)\*\*
+ 8\. \*\*UI/UX-Verbesserungen (mid)\*\*
 
 &#x20;  \* Fortschrittsbalken, Übersichtskarte, Drag-&-Drop für Module
-
-&#x20;    on
-
-\* Containerisiert (Docker)
-
-\* Python-basiert (z. B. Flask)
-
-\* Modularer Aufbau (JSON-Definitionen)
-
-\* Browser-Frontend (responsive)
-
-\* Konfigurierbare Faktortabellen (extern, z. B. JSON/DB)

--- a/module_system.py
+++ b/module_system.py
@@ -78,8 +78,19 @@ if __name__ == "__main__":
     global_def = ModuleDefinition.from_json(base / "global_mod.json")
     fb_def = ModuleDefinition.from_json(base / "foerderband_mod.json")
     sp_def = ModuleDefinition.from_json(base / "splitter_mod.json")
+    sc_def = ModuleDefinition.from_json(base / "schaltschrank_mod.json")
 
     modules = [
+        (
+            sc_def,
+            {
+                "id": "SC1",
+                "label": "Virtueller Schrank",
+                "virtual_cabinet": True,
+                "installation_type": "getrennte Aufstellung",
+                "main_switch_size": "400A",
+            },
+        ),
         (fb_def, {
             "id": "H101",
             "label": "Zuführband",

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -9,6 +9,8 @@ def calculate(params):
     length = params.get("length", 0) + params.get("avg_cable_length", 0)
     drives = params.get("drive_count", 1)
     common = params.get("common_starter", False)
+    factor = params.get("operating_load_factor", 0.8)
+    total_power = params.get("motor_rated_power", 0) * drives
 
     def build_components(power_kw, current, origin):
         if params.get("start_type") == "DOL":
@@ -78,5 +80,11 @@ def calculate(params):
                 "conduit_length": params.get("length", 0),
             }
         )
+    params.update(
+        {
+            "motor_rated_load": round(total_power, 2),
+            "motor_operating_load": round(total_power * factor, 2),
+        }
+    )
     return params
 

--- a/modules/foerderband_logic.py
+++ b/modules/foerderband_logic.py
@@ -10,17 +10,20 @@ def calculate(params):
     drives = params.get("drive_count", 1)
     common = params.get("common_starter", False)
 
-    def build_components(power_kw, current):
+    def build_components(power_kw, current, origin):
         if params.get("start_type") == "DOL":
-            return [
+            comps = [
                 {"type": "motor_protection", "power_class": f"{power_kw} kW", "rated_current": round(current, 2), "class": "10A"},
                 {"type": "contactor", "power_class": f"{power_kw} kW", "rated_current": round(current, 2)},
             ]
         else:
-            return [
+            comps = [
                 {"type": "circuit_breaker", "rated_current": round(current, 2)},
                 {"type": "frequency_inverter", "rated_current": round(current, 2)},
             ]
+        for c in comps:
+            c["origin"] = origin
+        return comps
 
     provided_cs = params.get("cable_cross_section")
 
@@ -41,7 +44,7 @@ def calculate(params):
                 "motor_rated_current": round(motor_current, 2),
                 "cable_cross_section": cross_section,
                 "voltage_drop_percent": round(drop_pct, 2),
-                "control_cabinet": build_components(power, motor_current),
+                "control_cabinet": build_components(power, motor_current, params.get("id")),
                 "conduit_length": params.get("length", 0),
             }
         )
@@ -67,7 +70,7 @@ def calculate(params):
                     "voltage_drop_percent": round(drop_pct, 2),
                 }
             )
-            components.extend(build_components(power, motor_current))
+            components.extend(build_components(power, motor_current, params.get("id")))
         params.update(
             {
                 "drives": drive_results,

--- a/modules/foerderband_mod.json
+++ b/modules/foerderband_mod.json
@@ -35,6 +35,12 @@
       "source": ["user"],
       "editableInFrontend": true
     },
+      "operating_load_factor": {
+      "datatype": "Decimal",
+      "defaultValue": 0.8,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
       "length": {
       "datatype": "Decimal",
       "defaultValue": 0,

--- a/modules/schaltschrank_logic.py
+++ b/modules/schaltschrank_logic.py
@@ -1,0 +1,8 @@
+def calculate(params):
+    size_str = str(params.get("main_switch_size", "0A"))
+    try:
+        size = int(size_str.rstrip("A"))
+    except ValueError:
+        size = 0
+    params["needs_supply_field"] = size >= 400
+    return params

--- a/modules/schaltschrank_logic.py
+++ b/modules/schaltschrank_logic.py
@@ -1,8 +1,14 @@
 def calculate(params):
-    size_str = str(params.get("main_switch_size", "0A"))
-    try:
-        size = int(size_str.rstrip("A"))
-    except ValueError:
-        size = 0
-    params["needs_supply_field"] = size >= 400
+    currents = params.get("motor_currents", [])
+    total_current = sum(currents)
+    required = total_current * 0.75
+    sizes = [63, 125, 250, 400, 630]
+    suggested = next((s for s in sizes if s >= required), sizes[-1])
+    params["main_switch_size"] = f"{suggested}A"
+    params["needs_supply_field"] = suggested >= 400
+    if suggested:
+        reserve = (suggested - required) / suggested * 100
+    else:
+        reserve = 0
+    params["capacity_reserve_percent"] = round(reserve, 2)
     return params

--- a/modules/schaltschrank_logic.py
+++ b/modules/schaltschrank_logic.py
@@ -11,4 +11,10 @@ def calculate(params):
     else:
         reserve = 0
     params["capacity_reserve_percent"] = round(reserve, 2)
+    params["total_motor_rated_load"] = round(
+        sum(params.get("motor_rated_loads", [])), 2
+    )
+    params["total_motor_operating_load"] = round(
+        sum(params.get("motor_operating_loads", [])), 2
+    )
     return params

--- a/modules/schaltschrank_mod.json
+++ b/modules/schaltschrank_mod.json
@@ -1,0 +1,46 @@
+{
+  "moduleName": "Schaltschrank",
+  "moduleId": "SC001",
+  "logic": "schaltschrank",
+  "parameters": {
+    "id": {
+      "datatype": "Text",
+      "defaultValue": "",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "label": {
+      "datatype": "Text",
+      "defaultValue": "",
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "virtual_cabinet": {
+      "datatype": "Bool",
+      "defaultValue": true,
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "installation_type": {
+      "datatype": "Auswahl",
+      "defaultValue": "getrennte Aufstellung",
+      "options": ["gemeinsame Aufstellung", "getrennte Aufstellung"],
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "main_switch_size": {
+      "datatype": "Auswahl",
+      "defaultValue": "63A",
+      "options": ["63A", "125A", "250A", "400A", "630A"],
+      "source": ["user"],
+      "editableInFrontend": true
+    },
+    "needs_supply_field": {
+      "datatype": "Bool",
+      "defaultValue": false,
+      "source": [],
+      "editableInFrontend": false
+    }
+  },
+  "steps": ["calculate"]
+}

--- a/modules/schaltschrank_mod.json
+++ b/modules/schaltschrank_mod.json
@@ -40,18 +40,42 @@
       "source": [],
       "editableInFrontend": false
     },
-    "elements": {
-      "datatype": "Liste",
-      "defaultValue": [],
-      "source": [],
-      "editableInFrontend": false
-    },
-    "motor_currents": {
-      "datatype": "Liste",
-      "defaultValue": [],
-      "source": [],
-      "editableInFrontend": false
-    }
+      "elements": {
+        "datatype": "Objekt",
+        "defaultValue": {},
+        "source": [],
+        "editableInFrontend": false
+      },
+      "motor_currents": {
+        "datatype": "Liste",
+        "defaultValue": [],
+        "source": [],
+        "editableInFrontend": false
+      },
+      "motor_rated_loads": {
+        "datatype": "Liste",
+        "defaultValue": [],
+        "source": [],
+        "editableInFrontend": false
+      },
+      "motor_operating_loads": {
+        "datatype": "Liste",
+        "defaultValue": [],
+        "source": [],
+        "editableInFrontend": false
+      },
+      "total_motor_rated_load": {
+        "datatype": "Decimal",
+        "defaultValue": 0,
+        "source": [],
+        "editableInFrontend": false
+      },
+      "total_motor_operating_load": {
+        "datatype": "Decimal",
+        "defaultValue": 0,
+        "source": [],
+        "editableInFrontend": false
+      }
   },
   "steps": ["calculate"]
 }

--- a/modules/schaltschrank_mod.json
+++ b/modules/schaltschrank_mod.json
@@ -21,23 +21,34 @@
       "source": ["user"],
       "editableInFrontend": true
     },
-    "installation_type": {
-      "datatype": "Auswahl",
-      "defaultValue": "getrennte Aufstellung",
-      "options": ["gemeinsame Aufstellung", "getrennte Aufstellung"],
-      "source": ["user"],
-      "editableInFrontend": true
-    },
     "main_switch_size": {
       "datatype": "Auswahl",
-      "defaultValue": "63A",
+      "defaultValue": null,
       "options": ["63A", "125A", "250A", "400A", "630A"],
-      "source": ["user"],
-      "editableInFrontend": true
+      "source": [],
+      "editableInFrontend": false
+    },
+    "capacity_reserve_percent": {
+      "datatype": "Decimal",
+      "defaultValue": null,
+      "source": [],
+      "editableInFrontend": false
     },
     "needs_supply_field": {
       "datatype": "Bool",
       "defaultValue": false,
+      "source": [],
+      "editableInFrontend": false
+    },
+    "elements": {
+      "datatype": "Liste",
+      "defaultValue": [],
+      "source": [],
+      "editableInFrontend": false
+    },
+    "motor_currents": {
+      "datatype": "Liste",
+      "defaultValue": [],
       "source": [],
       "editableInFrontend": false
     }

--- a/modules/splitter_logic.py
+++ b/modules/splitter_logic.py
@@ -10,11 +10,14 @@ def calculate(params):
     drives = params.get("drive_count", 1)
     common = params.get("common_starter", True)
 
-    def build_components(power_kw, current):
-        return [
+    def build_components(power_kw, current, origin):
+        comps = [
             {"type": "circuit_breaker", "rated_current": round(current, 2)},
             {"type": "frequency_inverter", "rated_current": round(current, 2)},
         ]
+        for c in comps:
+            c["origin"] = origin
+        return comps
 
     provided_cs = params.get("cable_cross_section")
 
@@ -35,7 +38,7 @@ def calculate(params):
                 "motor_rated_current": round(motor_current, 2),
                 "cable_cross_section": cross_section,
                 "voltage_drop_percent": round(drop_pct, 2),
-                "control_cabinet": build_components(power, motor_current),
+                "control_cabinet": build_components(power, motor_current, params.get("id")),
                 "conduit_length": params.get("length", 0),
             }
         )
@@ -61,7 +64,7 @@ def calculate(params):
                     "voltage_drop_percent": round(drop_pct, 2),
                 }
             )
-            components.extend(build_components(power, motor_current))
+            components.extend(build_components(power, motor_current, params.get("id")))
         params.update(
             {
                 "drives": drive_results,

--- a/modules/splitter_logic.py
+++ b/modules/splitter_logic.py
@@ -9,6 +9,8 @@ def calculate(params):
     length = params.get("length", 0) + params.get("avg_cable_length", 0)
     drives = params.get("drive_count", 1)
     common = params.get("common_starter", True)
+    factor = params.get("operating_load_factor", 0.8)
+    total_power = params.get("motor_rated_power", 0) * drives
 
     def build_components(power_kw, current, origin):
         comps = [
@@ -72,5 +74,11 @@ def calculate(params):
                 "conduit_length": params.get("length", 0),
             }
         )
+    params.update(
+        {
+            "motor_rated_load": round(total_power, 2),
+            "motor_operating_load": round(total_power * factor, 2),
+        }
+    )
     return params
 

--- a/modules/splitter_mod.json
+++ b/modules/splitter_mod.json
@@ -13,6 +13,7 @@
       "pull_cord": {"datatype": "Auswahl", "defaultValue": "links", "options": ["beidseitig", "links", "rechts", "einseitig", "keine"], "source": ["user"], "editableInFrontend": true},
       "drive_count": {"datatype": "Integer", "defaultValue": 1, "source": ["user"], "editableInFrontend": true},
       "common_starter": {"datatype": "Bool", "defaultValue": true, "source": ["user"], "editableInFrontend": true},
+      "operating_load_factor": {"datatype": "Decimal", "defaultValue": 0.8, "source": ["user"], "editableInFrontend": true},
       "cable_cross_section": {"datatype": "Decimal", "defaultValue": null, "source": ["user"], "editableInFrontend": true},
       "avg_cable_length": {"datatype": "Decimal", "defaultValue": null, "source": ["global", "user"], "reference": "avg_cable_length", "editableInFrontend": true},
       "supply_voltage": {"datatype": "Auswahl", "defaultValue": null, "options": ["400V", "600V"], "source": ["global"], "reference": "input_voltage", "editableInFrontend": false},


### PR DESCRIPTION
## Summary
- document actual global parameters and update README to use the `parameters` key
- describe a new Schaltschrank module and add a basic implementation with main switch sizing
- expand roadmap and adjust discrepancies

## Testing
- `python module_system.py`
- `python - <<'PY'
from pathlib import Path
from module_system import ModuleDefinition, ModuleRuntime
cab_def = ModuleDefinition.from_json(Path('modules/schaltschrank_mod.json'))
runtime = ModuleRuntime(cab_def, {"id": "SC1", "label": "Hauptschrank", "main_switch_size": "400A"})
print(runtime.run())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68988a06f8088322a75f31b97672bd9d